### PR TITLE
Revert "docs: add more build deps"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,7 @@ A beautiful cross-platform flashing tool.
 
 ## Development
 
-You'll first need to install the following dependencies: 
-
-- `go`
-- `pkg-config`
-- `webkit2gtk`.
-- `gtk4`
-- `gio-unix`
-- `glib2-devel`
-- `libsoup-devel`
-
-Install [Wails v3 Alpha](https://v3alpha.wails.io/) and [Bun](https://bun.sh), then run `wails dev` to start a development server with hot-reloading.
+You'll first need to install the following dependencies: `go`, `pkg-config`, and `webkit2gtk`. Install [Wails v3 Alpha](https://v3alpha.wails.io/) and [Bun](https://bun.sh), then run `wails dev` to start a development server with hot-reloading.
 
 ## Building
 


### PR DESCRIPTION
Reverts FyraLabs/moonshot#28

realized a couple of things:

webkit2gtk -> webkitgtk6
- `gio-unix`
- `glib2-devel`
- `libsoup-devel`
should be pulled in as transitive deps